### PR TITLE
Adds list_directory_contents public method to GithubClient

### DIFF
--- a/app/models/github_client.rb
+++ b/app/models/github_client.rb
@@ -31,6 +31,11 @@ class GithubClient
     content_contains?(decoded_file, search_string)
   end
 
+  def list_directory_contents(repo_name, path)
+    file_data = get_repo_file_data(repo_name, path)
+    file_data.map(&:name)
+  end
+
   private
 
   def repo_contents_client

--- a/app/models/null_response.rb
+++ b/app/models/null_response.rb
@@ -9,4 +9,8 @@ class NullResponse
   def content
     ''
   end
+
+  def map
+    ''
+  end
 end

--- a/spec/fixtures/files/repo_data_list_files
+++ b/spec/fixtures/files/repo_data_list_files
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "file",
+    "name": "octokit.rb"
+  },
+  {
+    "type": "dir",
+    "name": "octokitty"
+  }
+]

--- a/spec/models/github_client_spec.rb
+++ b/spec/models/github_client_spec.rb
@@ -88,4 +88,28 @@ RSpec.describe GithubClient do
       end
     end
   end
+
+  describe '#list_directory_contents' do
+    describe 'with valid response' do
+      before do
+        response = file_fixture('repo_data_list_files').read
+        stub_request(:any, /api.github.com/).to_return(status: 200, body: response)
+      end
+
+      it 'returns array of filenames' do
+        expect(client.list_directory_contents('fake', '/')).to eq ['octokit.rb', 'octokitty']
+      end
+    end
+
+    describe 'with invalid response' do
+      before do
+        response = file_fixture('repo_data_list_files').read
+        stub_request(:any, /api.github.com/).to_return(status: 404, body: response)
+      end
+
+      it 'returns empty string if path invalid' do
+        expect(client.list_directory_contents('fake', '/test')).to be ''
+      end
+    end
+  end
 end


### PR DESCRIPTION
Everything's pretty clean here except I wonder if the method name is misleading as it will list both file names as well as directory names. Would love thoughts on that distinction and how we could potentially handle the output of this method. Additionally, this code will return an empty string if it makes a query to a non existent path. We could, perhaps, be more explicit about the failed path.