### PR TITLE
Add servers index page

### DIFF
--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ServersController < ApplicationController
+  def index
+    @servers = Server.order(:hostname)
+  end
+end

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -14,7 +14,7 @@
             <div class='container'>
               <ul class='list-group'>
                 <% @repository.servers_deployed_to(environment).each do |server| %>
-                  <li class='list-group-item list-group-item-info'><%= server %></li>
+                  <li class='list-group-item list-group-item-info'><%= link_to "#{server}", "/servers##{server}", :target => "_blank" %></li>
                 <% end %>
               </ul>
             </div>

--- a/app/views/servers/index.html.erb
+++ b/app/views/servers/index.html.erb
@@ -1,0 +1,27 @@
+<div class="container">
+  <table class="table table-hover">
+    <thead>
+    </thead>
+    <tbody>
+        <% @servers.each do |s| %>
+        <tr>
+          <td>
+            <% if s.repositories.present? %>
+              <%= link_to "#{s.hostname}", repository_path(s.repositories.first.name), :id => "#{s.hostname}" %>
+            <% else %>
+              <span class="text-muted"><%= s.hostname %></span>
+            <% end %>
+          </td>
+          <td>
+            <% if s.ip %>
+              <span class="badge badge-repos badge-default"><%= s.ip %></span>
+            <% end %>
+            <% if s.pupgraded %>
+              <span class="badge badge-repos badge-default">pupgraded</span>
+            <% end %>
+          </td>
+        </tr>
+        <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -2,15 +2,22 @@
   <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a class="navbar-brand">Quimby</a>
+  <%= link_to 'Quimby', root_path, class: "navbar-brand" %>
   <div class="collapse navbar-collapse" id="navbarNav">
     <ul class="navbar-nav mr-auto">
-      <% if current_page?(repositories_path) %>
+      <% if current_page?(repositories_path) || current_page?(root_path) %>
       <li class="nav-item active">
       <% else %>
       <li class="nav-item">
       <% end %>
         <%= link_to 'Repositories', repositories_path, class: 'nav-link' %>
+      </li>
+      <% if current_page?(servers_path) %>
+      <li class="nav-item active">
+      <% else %>
+      <li class="nav-item">
+      <% end %>
+        <%= link_to 'Servers', servers_path, class: 'nav-link' %>
       </li>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root to: 'repositories#index'
   resources :repositories, only: [:show, :index]
+  resources :servers, only: [:index]
 end

--- a/spec/factories/servers.rb
+++ b/spec/factories/servers.rb
@@ -21,4 +21,10 @@ FactoryGirl.define do
     ip '123.45.67.891'
     dev_team 'devclub'
   end
+
+  factory :server_index, class: Server do
+    hostname 'server-dev'
+    ip '123.45.67.890'
+    pupgraded true
+  end
 end

--- a/spec/features/servers_table_spec.rb
+++ b/spec/features/servers_table_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Servers index table', type: :feature do
+  it 'displays server information' do
+    create(:server_index)
+    visit servers_path
+    expect(body).to have_text('server-dev')
+    expect(body).to have_text('123.45.67.890')
+    expect(body).to have_text('pupgraded')
+  end
+
+  it 'displays a link when server belongs to a deploy environment' do
+    create(:repo_with_servers)
+    visit servers_path
+    expect(body).to have_link('server-prod-b', href: '/repositories/Hello-World')
+  end
+end


### PR DESCRIPTION
When a server has a repository deployed to it, there will be back and forth links between the server's row in the server index, and the individual repository's show page.