### PR TITLE
added dependencies to rake tasks to make data load order explicit

### DIFF
--- a/lib/tasks/load_data.rake
+++ b/lib/tasks/load_data.rake
@@ -7,23 +7,19 @@ namespace :load_data do
   end
 
   desc 'loads repo data for the sul-dlss org'
-  task dlss: :environment do
+  task dlss: :servers do
     org = 'sul-dlss'
     RepoData.run(org)
     DeployData.run(org)
   end
 
   desc 'loads repo data for the sul-cidr org'
-  task cidr: :environment do
+  task cidr: :dlss do
     org = 'sul-cidr'
     RepoData.run(org)
     DeployData.run(org)
   end
 
-  desc 'loads it all'
-  task all: :environment do
-    Rake::Task['load_data:servers'].invoke
-    Rake::Task['load_data:dlss'].invoke
-    Rake::Task['load_data:cidr'].invoke
-  end
+  desc 'loads from all data sources in order'
+  task all: %i[environment servers dlss cidr]
 end


### PR DESCRIPTION
Closes #61 . Uncertain I like having the order forced via dependencies in each rake task (so you can't run any of them independently); just having dependencies declared in load_data:all may be sufficient. but want feedback on this.