### PR TITLE
Fixes navbar overlapping on each other

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,8 @@
 .badge-repos a:visited {
   color: #FFFFFF
 }
+
+.fixed-top-2 {
+    position: sticky;
+    top: 57px;
+}

--- a/app/views/repositories/_repo_navbar.html.erb
+++ b/app/views/repositories/_repo_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-light bg-faded sticky-top">
+<nav class="navbar navbar-light bg-faded fixed-top fixed-top-2">
   <%= form_tag repositories_path, method: :get, enforce_utf8: false , class: 'form-inline justify-content-center' do %>
     <label class="mr-sm-2">Language</label>
     <%= select_tag 'language', options_for_select(@repositories.collect { |repo| repo.language }.uniq, selected: params[:language]), include_blank: true, class: 'custom-select mr-sm-2' %>


### PR DESCRIPTION
Currently the filter navbar overlaps the main navbar on scroll up. This fixes that. 