### PR TITLE
Fix issue with gemnasium-found dependencies being empty

### DIFF
--- a/app/models/gemnasium_client.rb
+++ b/app/models/gemnasium_client.rb
@@ -28,7 +28,7 @@ class GemnasiumClient
 
       fetch_api("#{api}/projects/#{slug}/dependencies").each do |gem|
         next unless gem['package']['type'] == 'Rubygem'
-        dep = { name: gem['package']['name'], version: gem['locked'] }
+        dep = { 'name' => gem['package']['name'], 'version' => gem['locked'] }
         gems[slug].push(dep)
       end
     end

--- a/spec/models/repo_gemnasium_data_spec.rb
+++ b/spec/models/repo_gemnasium_data_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe RepoGemnasiumData do
       repo_gemnasium_data.load_data
       repo.reload
       expect(repo.dependencies.count).to eq 2
+      expect(repo.dependencies.first.name).to eq 'lyberteam-devel'
+      expect(repo.dependencies.second.name).to eq 'mediashelf-loggable'
     end
 
     it 'sets gemnasium count on matching repos without alerts' do


### PR DESCRIPTION
A refactor in reformatting the dependency data caused problems.  Tests
missed this as they were only checking the count of dependencies and
not the contents.  Fixed, with test expanded to catch this.